### PR TITLE
Move Upload button to the left side

### DIFF
--- a/filebrowser/templates/filebrowser/upload.html
+++ b/filebrowser/templates/filebrowser/upload.html
@@ -121,7 +121,7 @@
             <div class="module footer">
                 <ul class="submit-row">
                     <li class="left cancel-link-container"><a class="cancel-link" href="javascript://">{% trans "Clear Queue" %}</a></li>
-                    <li class="submit-button-container"><input class="default" type="submit" name="_save" value='{% trans "Upload" %}' /></li>
+                    <li class="left submit-button-container"><input class="default" type="submit" name="_save" value='{% trans "Upload" %}' /></li>
                 </ul>
             </div>
         </form>


### PR DESCRIPTION
In Chrome (atleast), Upload button is not visible while selecting files to upload due to x scrollbar. I suggest for UX improvement, to move it left.
