### PR TITLE
Adding grayscale option to FILEBROWSER_VERSION

### DIFF
--- a/filebrowser/functions.py
+++ b/filebrowser/functions.py
@@ -333,18 +333,17 @@ def version_generator(value, version_prefix, force=None, directory=DIRECTORY):
             os.makedirs(version_dir)
             os.chmod(version_dir, DEFAULT_PERMISSIONS)
         version = scale_and_crop(im, VERSIONS[version_prefix]['width'], VERSIONS[version_prefix]['height'], VERSIONS[version_prefix]['opts'])
-        if version:
-            try:
-                version.save(version_path, quality=VERSION_QUALITY, optimize=(os.path.splitext(version_path)[1].lower() != '.gif'))
-            except IOError:
-                version.save(version_path, quality=VERSION_QUALITY)
-        else:
-            # version wasn't created
-            # save the original image with the versions name
-            try:
-                im.save(version_path, quality=VERSION_QUALITY, optimize=(os.path.splitext(version_path)[1].lower() != '.gif'))
-            except IOError:
-                im.save(version_path, quality=VERSION_QUALITY)
+
+        if not version:
+            version = im
+
+        if 'grayscale' in VERSIONS[version_prefix]['opts']:
+            if version.mode != "L":
+                version = version.convert("L")
+        try:
+            version.save(version_path, quality=VERSION_QUALITY, optimize=(os.path.splitext(version_path)[1].lower() != '.gif'))
+        except IOError:
+            version.save(version_path, quality=VERSION_QUALITY)
         return version_path
     except:
         return None


### PR DESCRIPTION
For a new project, I had to manage grayscale version.

Here is the patch I made.
## USAGE :

**settings.py** :

```
FILEBROWSER_VERSIONS = {
  ...
  'slideshow': {'verbose_name': 'Slideshow', 'width': 655, 'height': 345, 'opts':'crop upscale grayscale'},
  }
```

**template.html**

```
{% version slideshow.image.path 'slideshow' %}
```

Then the image become grayscale.
