### PR TITLE
Issues with unescaped strings

### DIFF
--- a/filebrowser/templates/filebrowser/upload.html
+++ b/filebrowser/templates/filebrowser/upload.html
@@ -57,11 +57,11 @@
                 debug: false,
                 // messages
                 messages: {
-                    typeError: '{% trans "{file} has invalid extension. Only {extensions} are allowed." %}',
-                    sizeError: '{% trans "{file} is too large, maximum file size is {sizeLimit}." %}',
-                    minSizeError: '{% trans "{file} is too small, minimum file size is {minSizeLimit}." %}',
-                    emptyError: '{% trans "{file} is empty, please select files again without it." %}',
-                    onLeave: '{% trans "The files are being uploaded, if you leave now the upload will be cancelled." %}'
+                    typeError: "{% trans "{file} has invalid extension. Only {extensions} are allowed." %}",
+                    sizeError: "{% trans "{file} is too large, maximum file size is {sizeLimit}." %}",
+                    minSizeError: "{% trans "{file} is too small, minimum file size is {minSizeLimit}." %}",
+                    emptyError: "{% trans "{file} is empty, please select files again without it." %}",
+                    onLeave: "{% trans "The files are being uploaded, if you leave now the upload will be cancelled." %}"
                 },
 
                 getItem: function(id) {


### PR DESCRIPTION
Related to this issue: 

https://github.com/sehmaschine/django-filebrowser/issues/53

Changed singlequotes to quotes in locales config.
