### PR TITLE
sites.py: import Http404

### DIFF
--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -7,7 +7,7 @@ from types import MethodType
 # DJANGO IMPORTS
 from django.shortcuts import render_to_response, HttpResponse
 from django.template import RequestContext as Context
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, Http404
 from django.contrib.admin.views.decorators import staff_member_required
 from django.views.decorators.cache import never_cache
 from django.utils.translation import ugettext as _


### PR DESCRIPTION
The Http404 import was missing from sites.py. Hit it today.
