### PR TITLE
Better caching in base.py

### DIFF
--- a/filebrowser/base.py
+++ b/filebrowser/base.py
@@ -229,7 +229,7 @@ class FileObject():
     def _filesize(self):
         if self._filesize_stored != None:
             return self._filesize_stored
-        if self.site.storage.exists(self.path):
+        if self.exists():
             self._filesize_stored = self.site.storage.size(self.path)
             return self._filesize_stored
         return None
@@ -239,7 +239,7 @@ class FileObject():
     def _date(self):
         if self._date_stored != None:
             return self._date_stored
-        if self.site.storage.exists(self.path):
+        if self.exists():
             self._date_stored = time.mktime(self.site.storage.modified_time(self.path).timetuple())
             return self._date_stored
         return None
@@ -251,10 +251,11 @@ class FileObject():
         return None
     datetime = property(_datetime)
 
+    _exists_stored = None
     def exists(self):
-        if self.storage.isdir(self.path) or self.storage.isfile(self.path):
-            return True
-        return False
+        if self._exists_stored == None:
+            self._exists_stored = self.site.storage.exists(self.path)
+        return self._exists_stored
     
     # PATH/URL ATTRIBUTES
     


### PR DESCRIPTION
I'm playing around with using the S3Boto backend. When this is active, lots of operations in base.py suddenly become very expensive, and rendering a filebrowser view takes ages.

These patches fix some of the worst offenders by caching results:
- dimensions, which isn't called lots, but is very expensive when called, and a typical file listing was opening each file 3 or 4 times to get its height/width
- isdir, which is cheaper, but still expensive on S3, and is called quite frequently
- exists, which actually had a bug previously (self.storage does not exist).

Applying these patches improved timings by about 70%, but I'm finding the S3 backend still too slow to be usable for real work. To make it work properly would need much heavier use of caching and would probably involve breaking the current abstraction.
