### PR TITLE
Added dependency link to the Grappelli repo's 2.4 branch on GitHub.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,7 @@ setup(
     install_requires = [
         'django-grappelli >= 2.4.0',
     ],
+    dependency_links = [
+        'https://github.com/sehmaschine/django-grappelli.git@grappelli_2_4#egg=django-grappelli',
+    ]
 )


### PR DESCRIPTION
Without the dependancy link pip installs Grappelli (2.3.8) from PyPi which isn't compatible with either Django 1.4 or Grappelli 2.4.
