### PR TITLE
Pass correct filename to filebrowser_post_upload

### DIFF
--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -490,6 +490,8 @@ class FileBrowserSite(object):
                 old_file = smart_unicode(file_name)
                 new_file = smart_unicode(uploadedfile)
                 self.storage.move(new_file, old_file, allow_overwrite=True)
+            else:
+                file_name = smart_unicode(uploadedfile)
             
             signals.filebrowser_post_upload.send(sender=request, path=request.POST.get('folder'), file=FileObject(smart_unicode(file_name), site=self))
             


### PR DESCRIPTION
When OVERWRITE_EXISTING is set to False, we are not changing the file_name variable to reflect the filename of the newly uploaded file. Added that in else condition.
