### PR TITLE
Use 'allow_overwrite=True' on storage.move()

### DIFF
--- a/filebrowser/actions.py
+++ b/filebrowser/actions.py
@@ -42,7 +42,7 @@ def transpose_image(request, fileobjects, operation):
         try:
             saved_under = fileobject.site.storage.save(fileobject.path, tmpfile)
             if saved_under != fileobject.path:
-                fileobject.site.storage.move(saved_under, fileobject.path)
+                fileobject.site.storage.move(saved_under, fileobject.path, allow_overwrite=True)
             fileobject.delete_versions()
         finally:
             tmpfile.close()


### PR DESCRIPTION
When an action is performed on an image `allow_overwrite` should be True.

This problem doesn't happen when using the local file system because filebrowser uses `file_move_safe()` from django/core/files/move.py, and this function is broken: it ignores the `allow_overwrite` parameter if `os.rename()` works.
