### PR TITLE
Add current site instance to signals parameters

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -133,6 +133,7 @@ Sent before a an Upload starts. Arguments:
 
 * ``path``: Absolute server path to the file/folder
 * ``name``: Name of the file/folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _filebrowser_post_upload:
 
@@ -143,6 +144,7 @@ Sent after an Upload has finished. Arguments:
 
 * ``path``: Absolute server path to the file/folder
 * ``name``: Name of the file/folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _filebrowser_pre_delete:
 
@@ -153,6 +155,7 @@ Sent before an Item (File, Folder) is deleted. Arguments:
 
 * ``path``: Absolute server path to the file/folder
 * ``name``: Name of the file/folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _filebrowser_post_delete:
 
@@ -163,6 +166,7 @@ Sent after an Item (File, Folder) has been deleted. Arguments:
 
 * ``path``: Absolute server path to the file/folder
 * ``name``: Name of the file/folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _filebrowser_pre_createdir:
 
@@ -173,6 +177,7 @@ Sent before a new Folder is created. Arguments:
 
 * ``path``: Absolute server path to the folder
 * ``name``: Name of the new folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _filebrowser_post_createdir:
 
@@ -183,6 +188,7 @@ Sent after a new Folder has been created. Arguments:
 
 * ``path``: Absolute server path to the folder
 * ``name``: Name of the new folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _filebrowser_pre_rename:
 
@@ -194,6 +200,7 @@ Sent before an Item (File, Folder) is renamed. Arguments:
 * ``path``: Absolute server path to the file/folder
 * ``name``: Name of the file/folder
 * ``new_name``: New name of the file/folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _filebrowser_post_rename:
 
@@ -205,6 +212,7 @@ Sent after an Item (File, Folder) has been renamed.
 * ``path``: Absolute server path to the file/folder
 * ``name``: Name of the file/folder
 * ``new_name``: New name of the file/folder
+* ``site``: Current ``FileBrowserSite`` instance
 
 ``filebrowser_actions_pre_apply``
 ---------------------------------
@@ -213,6 +221,7 @@ Sent before a custom action is applied. Arguments:
 
 * ``action_name``: Name of the custom action
 * ``fileobjects``: A list of fileobjects the action will be applied to
+* ``site``: Current ``FileBrowserSite`` instance
 
 ``filebrowser_actions_post_apply``
 ----------------------------------
@@ -222,6 +231,7 @@ Sent after a custom action has been applied.
 * ``action_name``: Name of the custom action
 * ``fileobjects``: A list of fileobjects the action has been be applied to
 * ``results``: The response you defined with your custom action
+* ``site``: Current ``FileBrowserSite`` instance
 
 .. _signals_examples:
 

--- a/filebrowser/signals.py
+++ b/filebrowser/signals.py
@@ -4,21 +4,21 @@
 from django.dispatch import Signal
 
 # mkdir signals
-filebrowser_pre_createdir = Signal(providing_args=["path", "name"])
-filebrowser_post_createdir = Signal(providing_args=["path", "name"])
+filebrowser_pre_createdir = Signal(providing_args=["path", "name", "site"])
+filebrowser_post_createdir = Signal(providing_args=["path", "name", "site"])
 
 # delete signals
-filebrowser_pre_delete = Signal(providing_args=["path", "name"])
-filebrowser_post_delete = Signal(providing_args=["path", "name"])
+filebrowser_pre_delete = Signal(providing_args=["path", "name", "site"])
+filebrowser_post_delete = Signal(providing_args=["path", "name", "site"])
 
 # rename signals
-filebrowser_pre_rename = Signal(providing_args=["path", "name", "new_name"])
-filebrowser_post_rename = Signal(providing_args=["path", "name", "new_name"])
+filebrowser_pre_rename = Signal(providing_args=["path", "name", "new_name", "site"])
+filebrowser_post_rename = Signal(providing_args=["path", "name", "new_name", "site"])
 
 # action signals
-filebrowser_actions_pre_apply = Signal(providing_args=['action_name', 'fileobjects',])
-filebrowser_actions_post_apply = Signal(providing_args=['action_name', 'filebjects', 'result'])
+filebrowser_actions_pre_apply = Signal(providing_args=['action_name', 'fileobjects', 'site'])
+filebrowser_actions_post_apply = Signal(providing_args=['action_name', 'filebjects', 'result', 'site'])
 
 # upload signals
-filebrowser_pre_upload = Signal(providing_args=["path", "file"])
-filebrowser_post_upload = Signal(providing_args=["path", "file"])
+filebrowser_pre_upload = Signal(providing_args=["path", "file", "site"])
+filebrowser_post_upload = Signal(providing_args=["path", "file", "site"])


### PR DESCRIPTION
This is necessary on a multi-site configuration.
A signal handler may want to perform different actions depending on the current site, or use any site specific variable.

I think the `sender` parameter would be appropriate to be the current site instance. But this would break backwards compatibility.
