### PR TITLE
FileBrowseField __init__ should not have a return statement

### DIFF
--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -94,7 +94,7 @@ class FileBrowseField(CharField):
         self.directory = kwargs.pop('directory', '')
         self.extensions = kwargs.pop('extensions', '')
         self.format = kwargs.pop('format', '')
-        return super(FileBrowseField, self).__init__(*args, **kwargs)
+        super(FileBrowseField, self).__init__(*args, **kwargs)
     
     def to_python(self, value):
         if not value or isinstance(value, FileObject):


### PR DESCRIPTION
Let's say I have a model `FileModel` which has a `file` attribute which is a `FileBrowseField`. Now, `'file' in dir(FileModel)` will be `True`, however `hasattr(FileBrowseField, 'file')` will be 'False' and `getattr(FileBrowseField, 'file')` will raise an `AttributeError`. 

This behaviour is not consistent with Django model fields and can lead to unexpected problems when working with 3rd party libraries like Sphinx AutoDoc for example. 
