### PR TITLE
Raise exceptions from `functions.version_generator` when in debug

### DIFF
--- a/filebrowser/templatetags/fb_versions.py
+++ b/filebrowser/templatetags/fb_versions.py
@@ -124,7 +124,9 @@ class VersionObjectNode(Node):
             elif site.storage.modified_time(source) > site.storage.modified_time(version_path):
                 version_path = version_generator(source, version_prefix, force=True, site=site)
             context[self.var_name] = FileObject(version_path, site=site)
-        except:
+        except Exception as e:
+            if settings.TEMPLATE_DEBUG:
+                raise e
             context[self.var_name] = ""
         return ''
 


### PR DESCRIPTION
If you do not have PIL installed correctly and `version_generator` throws an exception, it is disregarded here, even in when `TEMPLATE_DEBUG` is `True`.  This makes it hard to determine why you can't select a different size version in the admin because what is passed back to the image selection window is a blank string.  Re-raising the exception here is helpful for debugging.
