### PR TITLE
Fixed traversal search function.

### DIFF
--- a/filebrowser/base.py
+++ b/filebrowser/base.py
@@ -83,6 +83,9 @@ class FileListing():
             for d in dirs:
                 self._walk(os.path.join(path, d), filelisting)
 
+        rel_path = path.replace(self.site.directory, '')
+        files = map(lambda x: os.path.join(rel_path, x), files)
+
         filelisting.extend(dirs)
         filelisting.extend(files)
 


### PR DESCRIPTION
If when I turn on FILEBROWSER_SEARCH_TRAVERSE option, django-filebrowser do not provide a path of image that contained sub-directories.
