### PR TITLE
Fix command fb_version_generate when VERSIONS_BASEDIR is set

### DIFF
--- a/filebrowser/management/commands/fb_version_generate.py
+++ b/filebrowser/management/commands/fb_version_generate.py
@@ -59,6 +59,7 @@ class Command(BaseCommand):
         # walkt throu the filebrowser directory
         # for all/new files (except file versions itself and excludes)
         for dirpath,dirnames,filenames in os.walk(path, followlinks=True):
+            rel_dir = os.path.relpath(dirpath, os.path.realpath(MEDIA_ROOT))
             for filename in filenames:
                 filtered = False
                 # no "hidden" files (stating with ".")
@@ -72,7 +73,7 @@ class Command(BaseCommand):
                     continue
                 (tmp, extension) = os.path.splitext(filename)
                 if extension in EXTENSIONS["Image"]:
-                    self.createVersions(os.path.join(dirpath, filename), selected_version)
+                    self.createVersions(os.path.join(rel_dir, filename), selected_version)
     
     def createVersions(self, path, selected_version):
         if selected_version:


### PR DESCRIPTION
When VERSIONS_BASEDIR is set, fb_version_generate ignores that settings and generate thumbnail next to original photos, because version_generator function requires path parameter to be relative to MEDIA_ROOT, but in current version absolute path is passed in and therefore os.path.join(VERSIONS_BASEDIR, path) ignores the first parameter (second one is absolute path).
