### PR TITLE
Extends FILEBROWSER_EXTENSIONS and add .docx

### DIFF
--- a/filebrowser/settings.py
+++ b/filebrowser/settings.py
@@ -38,7 +38,7 @@ PATH_TINYMCE = getattr(settings, "FILEBROWSER_PATH_TINYMCE", DEFAULT_PATH_TINYMC
 EXTENSIONS = getattr(settings, "FILEBROWSER_EXTENSIONS", {
     'Folder': [''],
     'Image': ['.jpg','.jpeg','.gif','.png','.tif','.tiff'],
-    'Document': ['.pdf','.doc','.rtf','.txt','.xls','.csv'],
+    'Document': ['.pdf','.doc','.rtf','.txt','.xls','.csv','.docx'],
     'Video': ['.mov','.wmv','.mpeg','.mpg','.avi','.rm'],
     'Audio': ['.mp3','.mp4','.wav','.aiff','.midi','.m4p']
 })


### PR DESCRIPTION
Popularity of docx are growing very fast. This is the default file format in new version Office. It is also supported by LibreOffice and many other software for manage documents.
