### PR TITLE
Bugfix: _upload returns wrong filename if file exists and OVERWRITE_EXISTING=False

### DIFF
--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -489,6 +489,7 @@ class FileBrowserSite(object):
                 self.storage.move(new_file, old_file, allow_overwrite=True)
             else:
                 file_name = smart_unicode(uploadedfile)
+                filedata.name = os.path.relpath(file_name, path)
             
             signals.filebrowser_post_upload.send(sender=request, path=request.POST.get('folder'), file=FileObject(smart_unicode(file_name), site=self), site=self)
             


### PR DESCRIPTION
bugfix: _upload returned not really uploaded file if file existed in filesystem. It returned old exist file, like a "1.jpg" instead of "1_1.jpg","1_2.jpg",.. etc
OVERWRITE_EXISTING = False
