### PR TITLE
Update custom_field.html

### DIFF
--- a/filebrowser/templates/filebrowser/custom_field.html
+++ b/filebrowser/templates/filebrowser/custom_field.html
@@ -1,6 +1,6 @@
 {% load i18n fb_versions %}
 <input id="{{ final_attrs.id }}" type="text" class="vFileBrowseField" name="{{ final_attrs.name }}" value="{{ value.path }}" /><a href="javascript:FileBrowser.show('{{ final_attrs.id }}', '{{ url }}?pop=1{% if final_attrs.directory %}&amp;dir={{ final_attrs.directory|urlencode|urlencode }}{% endif %}{% if final_attrs.format %}&amp;type={{ final_attrs.format }}{% endif %}');" class="fb_show"></a>
-{% if value.filetype == "Image" %}
+{% if value.filetype == "Image" and value.exists %}
 {% version_object value.path final_attrs.ADMIN_THUMBNAIL as thumbnail_version %}
 {% if thumbnail_version %}
 <p class="preview" id="preview_{{ final_attrs.id }}">


### PR DESCRIPTION
It's possible someone could manually change the path before trying to generate the thumbnail that this check protects.

Simple change to double check that "value.exists" before trying to generate a thumbnail.

I was seeing internal server errors upon save if I chose a file, then manually updated the path to it, or otherwise just put a nonsense path in the input field.  This patch fixed it.
