### PR TITLE
Set up version templatetags to use parser.compile_filter().

### DIFF
--- a/filebrowser/templatetags/fb_versions.py
+++ b/filebrowser/templatetags/fb_versions.py
@@ -1,13 +1,9 @@
 # coding: utf-8
 
-# PYTHON IMPORTS
-import os, re
-from time import gmtime
-
 # DJANGO IMPORTS
-from django.template import Library, Node, VariableDoesNotExist, TemplateSyntaxError
+from django.template import Library
 from django.conf import settings
-from django.utils.encoding import force_unicode, smart_str
+from django.utils.encoding import force_unicode
 from django.core.files import File
 
 
@@ -19,151 +15,72 @@ from filebrowser.sites import get_default_site
 register = Library()
 
 
-class VersionNode(Node):
-    def __init__(self, src, version_suffix):
-        self.src = src
-        self.version_suffix = version_suffix
-        
-    def render(self, context):
-        try:
-            source = self.src.resolve(context)
-            version_suffix = self.version_suffix.resolve(context)
-        except VariableDoesNotExist:
-            return ''
-        site = context.get('filebrowser_site', get_default_site())
-        directory = site.directory
-        try:
-            if isinstance(source, FileObject):
-                site = source.site
-                source = source.path
-            if isinstance(source, File):
-                source = source.name
-            source = force_unicode(source)
-            if FORCE_PLACEHOLDER:
-                source = PLACEHOLDER
-            elif SHOW_PLACEHOLDER and not site.storage.isfile(source):
-                source = PLACEHOLDER
-            version_path = get_version_path(source, version_suffix, site=site)
-            if not site.storage.isfile(version_path):
-                version_path = version_generator(source, version_suffix, site=site)
-            elif site.storage.modified_time(source) > site.storage.modified_time(version_path):
-                version_path = version_generator(source, version_suffix, force=True, site=site)
-            return site.storage.url(version_path)
-        except:
-            if settings.TEMPLATE_DEBUG:
-                raise
-        return ''
+def _get_version_path(context, source, version_suffix):
+    if version_suffix not in VERSIONS:
+        return None, ''
+    site = context.get('filebrowser_site', get_default_site())
+    if isinstance(source, FileObject):
+        site = source.site
+        source = source.path
+    if isinstance(source, File):
+        source = source.name
+    try:
+        source = force_unicode(source)
+        if FORCE_PLACEHOLDER:
+            source = PLACEHOLDER
+        elif SHOW_PLACEHOLDER and not site.storage.isfile(source):
+            source = PLACEHOLDER
+        version_path = get_version_path(source, version_suffix, site=site)
+        if not site.storage.isfile(version_path):
+            version_path = version_generator(source, version_suffix, site=site)
+        elif site.storage.modified_time(source) > site.storage.modified_time(version_path):
+            version_path = version_generator(source, version_suffix, force=True, site=site)
+    except:
+        if settings.TEMPLATE_DEBUG:
+            raise
+        return None, ''
+
+    return site, version_path
 
 
-def version(parser, token):
+@register.simple_tag(takes_context=True)
+def version(context, source, version_suffix):
     """
     Displaying a version of an existing Image according to the predefined VERSIONS settings (see filebrowser settings).
     {% version field_name.path version_suffix %}
-    
+
     Use {% version my_image.path 'medium' %} in order to display the medium-size
     version of an Image stored in a field name my_image.
-    
+
     version_suffix can be a string or a variable. if version_suffix is a string, use quotes.
     """
-    bits = token.split_contents()
-    tag_name = bits[0]
-
-    if len(bits) < 3:
-        raise TemplateSyntaxError("%s tag requires 2 arguments" % tag_name)
-
-    src = parser.compile_filter(bits[1])
-    version_suffix = parser.compile_filter(bits[2])
-    return VersionNode(src, version_suffix)
-
-
-class VersionObjectNode(Node):
-    def __init__(self, src, version_suffix, var_name):
-        self.var_name = var_name
-        self.src = src
-        self.version_suffix = version_suffix
-    
-    def render(self, context):
-        try:
-            source = self.src.resolve(context)
-            version_suffix = self.version_suffix.resolve(context)
-        except VariableDoesNotExist:
-            return ''
-        site = context.get('filebrowser_site', get_default_site())
-        directory = site.directory
-        try:
-            if isinstance(source, FileObject):
-                site = source.site
-                source = source.path
-            if isinstance(source, File):
-                source = source.name
-            source = force_unicode(source)
-            if FORCE_PLACEHOLDER:
-                source = PLACEHOLDER
-            elif SHOW_PLACEHOLDER and not site.storage.isfile(source):
-                source = PLACEHOLDER
-            version_path = get_version_path(source, version_suffix, site=site)
-            if not site.storage.isfile(version_path):
-                version_path = version_generator(source, version_suffix, site=site)
-            elif site.storage.modified_time(source) > site.storage.modified_time(version_path):
-                version_path = version_generator(source, version_suffix, force=True, site=site)
-            context[self.var_name] = FileObject(version_path, site=site)
-        except:
-            if settings.TEMPLATE_DEBUG:
-                raise
-            context[self.var_name] = ''
+    site, version_path = _get_version_path(context, source, version_suffix)
+    if not site or not version_path:
         return ''
+    return site.storage.url(version_path)
 
 
-def version_object(parser, token):
+@register.assignment_tag(takes_context=True)
+def version_object(context, source, version_suffix):
     """
     Returns a context variable 'version_object'.
     {% version_object field_name.path version_suffix %}
-    
-    Use {% version_object my_image.path 'medium' %} in order to retrieve the medium
-    version of an Image stored in a field name my_image.
-    Use {% version_object my_image.path 'medium' as var %} in order to use 'var' as
-    your context variable.
-    
+
+    Use {% version_object my_image.path 'medium' as var %} in order to retrieve the medium
+    version of an Image stored in a field name my_image and store it in the context as 'var'.
+
     version_suffix can be a string or a variable. if version_suffix is a string, use quotes.
     """
-    bits = token.split_contents()
-    tag_name = bits[0]
-    if len(bits) != 5:
-        raise TemplateSyntaxError("%s tag requires 4 arguments" % tag_name)
-    if bits[-2] != 'as':
-        raise TemplateSyntaxError("%s tag's third argument must be 'as'" % tag_name)
-    src = parser.compile_filter(bits[1])
-    version_suffix = parser.compile_filter(bits[2])
-    var_name = bits[4]
-    return VersionObjectNode(src, version_suffix, var_name)
-
-
-class VersionSettingNode(Node):
-    def __init__(self, version_suffix):
-        self.version_suffix = version_suffix
-    
-    def render(self, context):
-        try:
-            version_suffix = self.version_suffix.resolve(context)
-        except VariableDoesNotExist:
-            return ''
-        context['version_setting'] = VERSIONS[version_suffix]
+    site, version_path = _get_version_path(context, source, version_suffix)
+    if not site or not version_path:
         return ''
+    return FileObject(version_path, site=site)
 
 
-def version_setting(parser, token):
+@register.simple_tag(takes_context=True)
+def version_setting(context, version_suffix):
     """
     Get Information about a version setting.
     """
-    bits = token.split_contents()
-    tag_name = bits[0]
-    if len(bits) != 2:
-        raise TemplateSyntaxError("%s tag requires 1 argument" % tag_name)
-    version_suffix = parser.compile_filter(bits[1])
-    return VersionSettingNode(version_suffix)
-
-
-register.tag(version)
-register.tag(version_object)
-register.tag(version_setting)
-
+    context['version_setting'] = VERSIONS.get(version_suffix, '')
+    return ''


### PR DESCRIPTION
Pull request for #155.

Using parser.compile_filter() consistently has several benefits:
1. it makes the code cleaner, since everything (quoted strings as well as variables) can be treated as a variable which is resolved.
2. it removes the necessity for error-prone checking of whether something is a quoted string.
3. it allows filters to be used everywhere. For example, it would now be legal to say `{% version "hardcoded/path/to/th.ing" variable_size %}` or `{% version my_image.path|default:"path/to/default.jpg" version|default:"big" %}`
