### PR TITLE
Update sites.py

### DIFF
--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -199,7 +199,7 @@ class FileBrowserSite(object):
         for exp in EXCLUDE:
            filter_re.append(re.compile(exp))
         for k,v in VERSIONS.iteritems():
-            exp = (r'_%s(%s)') % (k, '|'.join(EXTENSION_LIST))
+            exp = (r'_%s(%s)$') % (k, '|'.join(EXTENSION_LIST))
             filter_re.append(re.compile(exp))
 
         def filter_browse(item):


### PR DESCRIPTION
This simple patch should correct the following behaviour  : 

Currently, a filename like my_bigbrother.pdf got filtered in the browse view, because the regex matches it as a file version of my.pdf

This is due to the default extension for folder which is an empty string, so the filtering regex pattern looks like:

```
#_big(|.pdf|.txt|.jpg|.etcaetera)#
```

Note the first | in the regex => it is the empty string representing folders extension.

So, the regex  is useless, it is somewhat equivalent to:   

```
#_big#
```

My patch simply propose to add the end string delimiter $, so pattern will look like this:

```
#_big(|.pdf|.txt|.jpg|.etcaetera)$#
```

Then, my_bigbrother.pdf will not be filtered, but my_bigbrother_big.pdf, will.

regards.
Rodrigue
