### PR TITLE
Filing issue where uppercase extensions will be ignored by filter

### DIFF
--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -282,7 +282,7 @@ class FileBrowserSite(object):
             filter_re.append(re.compile(exp))
         for k, v in VERSIONS.iteritems():
             exp = (r'_%s(%s)$') % (k, '|'.join(EXTENSION_LIST))
-            filter_re.append(re.compile(exp, re.IGNORECASE)))
+            filter_re.append(re.compile(exp, re.IGNORECASE))
 
         def filter_browse(item):
             "Defining a browse filter"


### PR DESCRIPTION
This fixes an issue where `photo_admin_thumbnail.jpg` would match and thus not display in the list whereas `photo_admin_thumbnail.JPG` would display in the directory listing (and also create `photo_admin_thumbnail_admin_thumbnail.JPG` in the process, which would then create `photo_admin_thumbnail_admin_thumbnail_admin_thumbnail.JPG`)
