### PR TITLE
Fixed file selection after using search box (CKEditor).

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Patrick Kranzlmueller <patrick@vonautomatisch.at>
 Axel Swoboda <axel@vonautomatisch.at>
 Klemens Mantzos <klemens@fetzig.at>
 Vaclav Mikolasek <vaclav.mikolasek@gmail.com>
+Tim Graham <timograham@gmail.com>

--- a/filebrowser/templates/filebrowser/index.html
+++ b/filebrowser/templates/filebrowser/index.html
@@ -101,6 +101,10 @@
                             {% if query.type %}<input type="hidden" name="type" value="{{ query.type }}" />{% endif %}
                             {% if query.format %}<input type="hidden" name="format" value="{{ query.format }}" />{% endif %}
                             {% if query.dir %}<input type="hidden" name="dir" value="{{ query.dir|urlencode }}" />{% endif %}
+                            {% ifequal query.pop '3' %} {# Custom CKEditor fields #}
+                                {% if query.CKEditor %}<input type="hidden" name="CKEditor" value="{{ query.CKEditor }}" />{% endif %}
+                                {% if query.CKEditorFuncNum %}<input type="hidden" name="CKEditorFuncNum" value="{{ query.CKEditorFuncNum }}" />{% endif %}
+                            {% endifequal %}
                             <button class="grp-search-button" type="submit" value="">&nbsp;</button>
                         </form>
                     </div>

--- a/filebrowser/tests/test_sites.py
+++ b/filebrowser/tests/test_sites.py
@@ -56,6 +56,26 @@ def test_browse(test):
     test.assertTrue(test.site.directory == response.context['filebrowser_site'].directory)
 
 
+def test_ckeditor_params_in_search_form(test):
+    """
+    The CKEditor GET params must be included in the search form as hidden
+    inputs so they persist after searching.
+    """
+    url = reverse('%s:fb_browse' % test.site_name)
+    response = test.c.get(url, {
+        'pop': '3',
+        'type': 'image',
+        'CKEditor': 'id_body',
+        'CKEditorFuncNum': '1',
+    })
+
+    test.assertTrue(response.status_code == 200)
+    test.assertContains(response, '<input type="hidden" name="pop" value="3" />')
+    test.assertContains(response, '<input type="hidden" name="type" value="image" />')
+    test.assertContains(response, '<input type="hidden" name="CKEditor" value="id_body" />')
+    test.assertContains(response, '<input type="hidden" name="CKEditorFuncNum" value="1" />')
+
+
 def test_createdir(test):
     """
     Check the createdir view functions as expected. Creates a new tmp directory
@@ -378,6 +398,7 @@ def runTest(self):
     self.assertTrue(response)
     # Execute tests
     test_browse(self)
+    test_ckeditor_params_in_search_form(self)
     test_createdir(self)
     test_upload(self)
     test_do_upload(self)


### PR DESCRIPTION
Added CKEditor params to the search form hidden inputs so they persist
after searching.

If this fix looks good, I'll add a test.
