### PR TITLE
Removed encoding of file URIs with CKEditor, fixed #210.

### DIFF
--- a/filebrowser/static/filebrowser/js/FB_CKEditor.js
+++ b/filebrowser/static/filebrowser/js/FB_CKEditor.js
@@ -17,8 +17,7 @@ function gup( name ) {
 
 function OpenFile(fileUrl) {
     var CKEditorFuncNum = gup('CKEditorFuncNum');
-    window.top.opener.CKEDITOR.tools.callFunction(CKEditorFuncNum,encodeURI(fileUrl).replace('#','%23'));
+    window.top.opener.CKEDITOR.tools.callFunction(CKEditorFuncNum, fileUrl);
     window.top.close();
     window.top.opener.focus();
 }
-


### PR DESCRIPTION
File URIs are already encoded in the template by
django.core.files.storage.FileSystemStorage.url(). Escaping
the URI in JavaScript resulted in double encoding of special
characters.
