### PR TITLE
Update fb_version_generate.py

### DIFF
--- a/filebrowser/management/commands/fb_version_generate.py
+++ b/filebrowser/management/commands/fb_version_generate.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
                 else:
                     self.stdout.write('generating all versions for: %s\n' % fileobject.path)
                     for version in VERSIONS:
-                        versionobject = fileobject.version_generate(selected_version)  # FIXME force?
+                        versionobject = fileobject.version_generate(version)  # FIXME force?
 
         # # walkt throu the filebrowser directory
         # # for all/new files (except file versions itself and excludes)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/izaak/projects/nospr/eggs/Django-1.5.5-py2.7.egg/django/core/management/base.py", line 222, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/izaak/projects/nospr/eggs/Django-1.5.5-py2.7.egg/django/core/management/base.py", line 255, in execute
    output = self.handle(*args, **options)
  File "/home/izaak/projects/nospr/eggs/django_filebrowser-3.5.6-py2.7.egg/filebrowser/management/commands/fb_version_generate.py", line 74, in handle
    versionobject = fileobject.version_generate(selected_version)  # FIXME force?
  File "/home/izaak/projects/nospr/eggs/django_filebrowser-3.5.6-py2.7.egg/filebrowser/base.py", line 506, in version_generate
    version_path = self.version_path(version_suffix)
  File "/home/izaak/projects/nospr/eggs/django_filebrowser-3.5.6-py2.7.egg/filebrowser/base.py", line 501, in version_path
    return os.path.join(self.versions_basedir, self.dirname, self.version_name(version_suffix))
  File "/home/izaak/projects/nospr/eggs/django_filebrowser-3.5.6-py2.7.egg/filebrowser/base.py", line 497, in version_name
    return self.filename_root + "_" + version_suffix + self.extension
TypeError: coercing to Unicode: need string or buffer, NoneType found