### PR TITLE
Fixed renaming UTF-8  problems

### DIFF
--- a/filebrowser/decorators.py
+++ b/filebrowser/decorators.py
@@ -40,7 +40,7 @@ def path_exists(site, function):
         if get_path(request.GET.get('dir', ''), site=site) is None:
             msg = _('The requested Folder does not exist.')
             messages.add_message(request, messages.ERROR, msg)
-            redirect_url = reverse("filebrowser:fb_browse", current_app=site.name) + query_helper(request.GET, "", "dir")
+            redirect_url = reverse("filebrowser:fb_browse", current_app=site.name) + query_helper(request.GET, u"", "dir")
             return HttpResponseRedirect(redirect_url)
         return function(request, *args, **kwargs)
     return decorator
@@ -54,13 +54,13 @@ def file_exists(site, function):
         if file_path is None:
             msg = _('The requested File does not exist.')
             messages.add_message(request, messages.ERROR, msg)
-            redirect_url = reverse("filebrowser:fb_browse", current_app=site.name) + query_helper(request.GET, "", "dir")
+            redirect_url = reverse("filebrowser:fb_browse", current_app=site.name) + query_helper(request.GET, u"", "dir")
             return HttpResponseRedirect(redirect_url)
         elif file_path.startswith('/') or file_path.startswith('..'):
             # prevent path traversal
             msg = _('You do not have permission to access this file!')
             messages.add_message(request, messages.ERROR, msg)
-            redirect_url = reverse("filebrowser:fb_browse", current_app=site.name) + query_helper(request.GET, "", "dir")
+            redirect_url = reverse("filebrowser:fb_browse", current_app=site.name) + query_helper(request.GET, u"", "dir")
             return HttpResponseRedirect(redirect_url)
         return function(request, *args, **kwargs)
     return decorator

--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -370,7 +370,7 @@ class FileBrowserSite(object):
                     self.storage.makedirs(server_path)
                     signals.filebrowser_post_createdir.send(sender=request, path=server_path, name=form.cleaned_data['name'], site=self)
                     messages.add_message(request, messages.SUCCESS, _('The Folder %s was successfully created.') % form.cleaned_data['name'])
-                    redirect_url = reverse("filebrowser:fb_browse", current_app=self.name) + query_helper(query, "ot=desc,o=date", "ot,o,filter_type,filter_date,q,p")
+                    redirect_url = reverse("filebrowser:fb_browse", current_app=self.name) + query_helper(query, u"ot=desc,o=date", "ot,o,filter_type,filter_date,q,p")
                     return HttpResponseRedirect(redirect_url)
                 except OSError as e:
                     errno = e.args[0]
@@ -453,7 +453,7 @@ class FileBrowserSite(object):
             except OSError:
                 # TODO: define error-message
                 pass
-        redirect_url = reverse("filebrowser:fb_browse", current_app=self.name) + query_helper(query, "", "filename,filetype")
+        redirect_url = reverse("filebrowser:fb_browse", current_app=self.name) + query_helper(query, u"", "filename,filetype")
         return HttpResponseRedirect(redirect_url)
 
     def detail(self, request):
@@ -490,9 +490,9 @@ class FileBrowserSite(object):
                     if isinstance(action_response, HttpResponse):
                         return action_response
                     if "_continue" in request.POST:
-                        redirect_url = reverse("filebrowser:fb_detail", current_app=self.name) + query_helper(query, "filename="+new_name, "filename")
+                        redirect_url = reverse("filebrowser:fb_detail", current_app=self.name) + query_helper(query, u"filename=" + new_name, "filename")
                     else:
-                        redirect_url = reverse("filebrowser:fb_browse", current_app=self.name) + query_helper(query, "", "filename")
+                        redirect_url = reverse("filebrowser:fb_browse", current_app=self.name) + query_helper(query, u"", "filename")
                     return HttpResponseRedirect(redirect_url)
                 except OSError:
                     form.errors['name'] = forms.util.ErrorList([_('Error.')])

--- a/filebrowser/templatetags/fb_tags.py
+++ b/filebrowser/templatetags/fb_tags.py
@@ -74,15 +74,15 @@ def string_to_dict(string):
 
     kwargs = {}
     if string:
-        string = str(string)
-        if ',' not in string:
+        string = unicode(string)
+        if u',' not in string:
             # ensure at least one ','
-            string += ','
-        for arg in string.split(','):
+            string += u','
+        for arg in string.split(u','):
             arg = arg.strip()
             if arg == '':
                 continue
-            kw, val = arg.split('=', 1)
+            kw, val = arg.split(u'=', 1)
             kwargs[kw] = val
     return kwargs
 


### PR DESCRIPTION
When we had a filename with nonascii characters and when we were renaming the file it went broken giving a traceback like the following.  We fix that problem with this patch on the string_to_dict helper function.

Traceback:

    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
      112.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/filebrowser/decorators.py" in decorator
      65.         return function(request, *args, **kwargs)
    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/filebrowser/decorators.py" in decorator
      45.         return function(request, *args, **kwargs)
    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/django/contrib/admin/views/decorators.py" in _checklogin
      17.             return view_func(request, *args, **kwargs)
    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
      52.         response = view_func(request, *args, **kwargs)
    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/filebrowser/sites.py" in detail
      493.                         redirect_url = reverse("filebrowser:fb_detail", current_app=self.name) + query_helper(query, "filename="+new_name, "filename")
    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/filebrowser/templatetags/fb_tags.py" in query_helper
      39.     add = string_to_dict(add)
    File "/Users/igortamara/.virtualenvs/co_web/lib/python2.7/site-packages/filebrowser/templatetags/fb_tags.py" in string_to_dict
      77.         string = str(string)

    Exception Type: UnicodeEncodeError at /admin/filebrowser/detail/
    Exception Value: 'ascii' codec can't encode character u'\xf3' in position 26: ordinal not in range(128)
