### PR TITLE
Rescale Bug Fix

### DIFF
--- a/filebrowser/utils.py
+++ b/filebrowser/utils.py
@@ -62,7 +62,7 @@ def scale_and_crop(im, width, height, opts):
 
     x, y = [float(v) for v in im.size]
 
-    if 'upscale' not in opts and x < width:
+    if 'upscale' not in opts and x < width and y < height:
         # version would be bigger than original
         # no need to create this version, because "upscale" isn't defined.
         return False


### PR DESCRIPTION
Hi,

I consider this a bug.
I had the following situation: There was an image that was 61x59 px and I made a version preset with a size of 60x30 px. It did not rescale the image, even though I expecet it to do so. When I changed the version size to 64x32 px, it did rescale the image.
This is my suggestion to fix it.