### PR TITLE
Added back button in upload window (taken from no-grappelli version)

### DIFF
--- a/filebrowser/templates/filebrowser/custom_field.html
+++ b/filebrowser/templates/filebrowser/custom_field.html
@@ -1,5 +1,24 @@
 {% load i18n fb_versions %}
-<input id="{{ final_attrs.id }}" type="text" class="vFileBrowseField{% if final_attrs.class %} {{ final_attrs.class }}{% endif %}" name="{{ final_attrs.name }}" value="{{ value.path }}" /><a href="javascript:FileBrowser.show('{{ final_attrs.id }}', '{{ url }}?pop=1{% if final_attrs.directory %}&amp;dir={{ final_attrs.directory|urlencode|urlencode }}{% endif %}{% if final_attrs.format %}&amp;type={{ final_attrs.format }}{% endif %}');" class="fb_show"></a>
+<input
+        id="{{ final_attrs.id }}"
+        type="text"
+        class="vFileBrowseField{% if final_attrs.class %} {{ final_attrs.class }}{% endif %}"
+        name="{{ final_attrs.name }}"
+        data-dir="{% if final_attrs.directory %}{{ final_attrs.directory|urlencode|urlencode }}{% endif %}"
+        data-type="{% if final_attrs.format %}{{ final_attrs.format }}{% endif %}"
+        value="{{ value.path }}" />
+<a class="fb_show js_vFileBrowseField{% if final_attrs.id %} {{ final_attrs.id }}{% endif %}" href="#"></a>
+
+<script>
+    django.jQuery('body').on('click', '.js_vFileBrowseField', function (ev) {
+        ev.preventDefault();
+        FileBrowser.show(
+            django.jQuery(ev.target).prev().attr('id'),
+            '{{ url }}?pop=1&' + django.jQuery.param(django.jQuery(ev.target).prev().data())
+        );
+    });
+</script>
+
 {% if value.filetype == "Image" and value.exists %}
 {% version_object value.path final_attrs.ADMIN_THUMBNAIL as thumbnail_version %}
 {% if thumbnail_version %}

--- a/filebrowser/templates/filebrowser/upload.html
+++ b/filebrowser/templates/filebrowser/upload.html
@@ -117,6 +117,15 @@
                 {% trans "Please enable Javascript to upload files." %}
             </noscript>
         </div>
+        <div style="padding: 6px 20px; text-align: right">
+            {% for item in breadcrumbs %}
+                {% if forloop.last %}
+                    <strong><a href="{% url 'filebrowser:fb_browse' %}{% query_string "" "q,dir,filename,p" %}&amp;dir={{ item.1|urlencode }}">{% trans "Back" %}</a></strong>
+                {% endif %}
+            {% empty %}
+                <strong><a href="{% url 'filebrowser:fb_browse' %}{% query_string "" "q,dir,filename,p" %}&amp;dir={{ item.1|urlencode }}">{% trans "Back" %}</a></strong>
+            {% endfor %}
+        </div>
         </fieldset>
         <fieldset class="grp-module grp-collapse grp-closed">
             <h2 class="grp-collapse-handler">{% trans "Help" %}</h2>


### PR DESCRIPTION
Users, who are using file browser on a daily basis, were having some complaints about not having a back-button in the upload form. I found that the no-grappelli had one recently added, so added it to this version aswel. Did extensive testing and it works well.

![backbtn](https://cloud.githubusercontent.com/assets/6339476/7339356/ee6f2fde-ec6b-11e4-9956-c1b7e57e43d2.png)
