### PR TITLE
Updated django-grappelli maximum version in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
     ],
     zip_safe = False,
     install_requires = [
-        'django-grappelli>=2.4,<2.6.99',
+        'django-grappelli>=2.4,<2.7.99',
     ],
 )


### PR DESCRIPTION
The current install_requires cause the uninstall of the latest grappelli version and in some cases can even cause failed builds as explained in #273. 

I've run tests with django 1.8, django grappelli 2.7.1 and latest master, everything runs smoothly.