### PR TITLE
Update video extensions for common HTML5 video types.

### DIFF
--- a/filebrowser/settings.py
+++ b/filebrowser/settings.py
@@ -22,8 +22,8 @@ EXTENSIONS = getattr(settings, "FILEBROWSER_EXTENSIONS", {
     'Folder': [''],
     'Image': ['.jpg', '.jpeg', '.gif', '.png', '.tif', '.tiff'],
     'Document': ['.pdf', '.doc', '.rtf', '.txt', '.xls', '.csv', '.docx'],
-    'Video': ['.mov', '.wmv', '.mpeg', '.mpg', '.avi', '.rm'],
-    'Audio': ['.mp3', '.mp4', '.wav', '.aiff', '.midi', '.m4p']
+    'Video': ['.mov', '.mp4', '.m4v', '.webm', '.wmv', '.mpeg', '.mpg', '.avi', '.rm'],
+    'Audio': ['.mp3', '.wav', '.aiff', '.midi', '.m4p']
 })
 # Define different formats for allowed selections.
 # This has to be a subset of EXTENSIONS.


### PR DESCRIPTION
I moved .mp4 to Video, as it's a video format not an audio format, and added the common .m4v and .webm types used for HTML5 video.

This should prevent a lot of people having to overwrite this setting just to get those types.