### PR TITLE
Avoid strict dependency on os when setting file permission during upload

### DIFF
--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -568,18 +568,16 @@ class FileBrowserSite(object):
             uploadedfile = handle_file_upload(path, filedata, site=self)
 
             if file_already_exists and OVERWRITE_EXISTING:
-                old_file = smart_text(file_path)
+                file_name = smart_text(file_path)
                 new_file = smart_text(uploadedfile)
-                self.storage.move(new_file, old_file, allow_overwrite=True)
-                full_path = FileObject(smart_text(old_file), site=self).path_full
+                self.storage.move(new_file, file_name, allow_overwrite=True)
             else:
                 file_name = smart_text(uploadedfile)
                 filedata.name = os.path.relpath(file_name, path)
-                full_path = FileObject(smart_text(file_name), site=self).path_full
 
             # set permissions
             if DEFAULT_PERMISSIONS is not None:
-                os.chmod(full_path, DEFAULT_PERMISSIONS)
+                self.storage.setpermission(file_name)
 
             f = FileObject(smart_text(file_name), site=self)
             signals.filebrowser_post_upload.send(sender=request, path=folder, file=f, site=self)

--- a/filebrowser/storage.py
+++ b/filebrowser/storage.py
@@ -45,7 +45,7 @@ class StorageMixin(object):
         """
         raise NotImplementedError()
 
-    def setpermission(self, name)
+    def setpermission(self, name):
         """
         Sets file permission
         """

--- a/filebrowser/storage.py
+++ b/filebrowser/storage.py
@@ -45,6 +45,11 @@ class StorageMixin(object):
         """
         raise NotImplementedError()
 
+    def setpermission(self, name)
+        """
+        Sets file permission
+        """
+        raise NotImplementedError()
 
 class FileSystemStorageMixin(StorageMixin):
 
@@ -63,6 +68,9 @@ class FileSystemStorageMixin(StorageMixin):
     def rmtree(self, name):
         shutil.rmtree(self.path(name))
 
+    def setpermission(self, name):
+        full_path = FileObject(smart_text(name), site=self).path_full
+        os.chmod(full_path, DEFAULT_PERMISSIONS)
 
 class S3BotoStorageMixin(StorageMixin):
 
@@ -113,3 +121,6 @@ class S3BotoStorageMixin(StorageMixin):
         dirlist = self.bucket.list(self._encode_name(name))
         for item in dirlist:
             item.delete()
+
+    def setpermission(self, name):
+        raise NotImplementedError()

--- a/filebrowser/storage.py
+++ b/filebrowser/storage.py
@@ -123,4 +123,7 @@ class S3BotoStorageMixin(StorageMixin):
             item.delete()
 
     def setpermission(self, name):
-        raise NotImplementedError()
+        # Permissions for S3 uploads with django-storages
+        # is set in settings.py with AWS_DEFAULT_ACL.
+        # More info: http://django-common-configs.readthedocs.org/en/latest/configs/storage.html
+        pass


### PR DESCRIPTION
<strong>Tests: OK
Version: FileBrowser 3.6.1, Grappelli 2.7.1, Django 1.8.4</strong>

In the function _upload_file in the sites module, there is a strict dependency on os.chmod. os.chmod will be called independently of the underlying storage provider. Thus, if using S3BotoStorage as storage backend, os.chmod will be executed even though the file is not to be stored locally. 

Furthermore, FileObject.path_full will be called, which in turn will call path on the underlying storage provider. As specified in the [File Storage Django documentation](https://docs.djangoproject.com/en/1.8/ref/files/storage/ "File Storage Django"), this is only to be implemented for local filesystems. Hence, this will cause Filebrowser to throw an NotImplementedError when using S3BotoStorage as Storage provider.

This can easily be resolved by abstracting the setting of file permissions to the StorageMixin. The correct way to set file permissions for the underlying storage will then be called, rather than calling os.chmod independently of the underlying storage provider.

The following pull requests suggests such an implementation. 