### PR TITLE
Change get_path and get_file to require site parameter.

### DIFF
--- a/filebrowser/decorators.py
+++ b/filebrowser/decorators.py
@@ -15,14 +15,14 @@ from django.utils.encoding import smart_text
 from filebrowser.templatetags.fb_tags import query_helper
 
 
-def get_path(path, site=None):
+def get_path(path, site):
     "Get path."
     if path.startswith('.') or os.path.isabs(path) or not site.storage.isdir(os.path.join(site.directory, path)):
         return None
     return path
 
 
-def get_file(path, filename, site=None):
+def get_file(path, filename, site):
     "Get file (or folder)."
     converted_path = smart_text(os.path.join(site.directory, path, filename))
     if not site.storage.isfile(converted_path) and not site.storage.isdir(converted_path):


### PR DESCRIPTION
Both of these functions can throw exceptions if site is not passed when
accessing site.storage.

The other option is to test for site before accessing site.storage with an `hasattr(site, 'storage')`. I checked all uses of both functions though and all current uses have site being specified.