### PR TITLE
Fix for unexisting settings.TEMPLATE_DEBUG in version templatetag

### DIFF
--- a/filebrowser/templatetags/fb_versions.py
+++ b/filebrowser/templatetags/fb_versions.py
@@ -45,10 +45,10 @@ class VersionNode(Node):
             else:
                 return version.url
         except Exception:
-            if settings.TEMPLATE_DEBUG:
-                raise
             if self.var_name:
                 context[self.var_name] = ""
+            if getattr(settings, 'TEMPLATE_DEBUG', True):
+                raise
         return ""
 
 


### PR DESCRIPTION
Settings.TEMPLATE_DEBUG parameter was finally removed in Django 1.10. After the change the code will be compatible with current and previous Django versions. Currently, the exception is catched higher and re-raised if needed.