### PR TITLE
Update imports for django 2.0

### DIFF
--- a/filebrowser/decorators.py
+++ b/filebrowser/decorators.py
@@ -4,10 +4,9 @@ import os
 
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-import django
-if django.VERSION >= (2, 0):
+try:
     from django.urls import reverse
-else:
+except ImportError: # Django < 2.0
     from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.encoding import smart_text

--- a/filebrowser/decorators.py
+++ b/filebrowser/decorators.py
@@ -4,10 +4,7 @@ import os
 
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-try:
-    from django.urls import reverse
-except ImportError: # Django < 2.0
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _

--- a/filebrowser/decorators.py
+++ b/filebrowser/decorators.py
@@ -4,7 +4,11 @@ import os
 
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+import django
+if django.VERSION >= (2, 0):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _

--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -2,10 +2,7 @@
 import os
 
 from django import forms
-try:
-    from django.urls import reverse
-except ImportError: # Django < 2.0
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models.fields import CharField
 from django.forms.widgets import Input
 from django.template.loader import render_to_string

--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -2,7 +2,10 @@
 import os
 
 from django import forms
-from django.core import urlresolvers
+try:
+    from django.urls import reverse
+except ImportError: # Django < 2.0
+    from django.core.urlresolvers import reverse
 from django.db.models.fields import CharField
 from django.forms.widgets import Input
 from django.template.loader import render_to_string
@@ -33,7 +36,7 @@ class FileBrowseWidget(Input):
         super(FileBrowseWidget, self).__init__(attrs)
 
     def render(self, name, value, attrs=None):
-        url = urlresolvers.reverse(self.site.name + ":fb_browse")
+        url = reverse(self.site.name + ":fb_browse")
         if value is None:
             value = ""
         if value != "" and not isinstance(value, FileObject):
@@ -153,7 +156,7 @@ class FileBrowseUploadWidget(Input):
         super(FileBrowseUploadWidget, self).__init__(attrs)
 
     def render(self, name, value, attrs=None):
-        url = urlresolvers.reverse(self.site.name + ":fb_browse")
+        url = reverse(self.site.name + ":fb_browse")
         if value is None:
             value = ""
         if value != "" and not isinstance(value, FileObject):

--- a/filebrowser/namers.py
+++ b/filebrowser/namers.py
@@ -2,9 +2,10 @@ from __future__ import unicode_literals
 import re
 from django.utils import six
 from django.utils.module_loading import import_string
-import django
-if django.VERSION <= (2, 0):
+try:
     from django.utils.text import force_text
+except ImportError:
+    pass
 
 from .settings import VERSIONS, VERSION_NAMER
 
@@ -36,13 +37,13 @@ class VersionNamer(object):
 class OptionsNamer(VersionNamer):
 
     def get_version_name(self):
-        if django.VERSION <= (2, 0):
+        try: # Django < 2.0
             name = "{root}_{options}{extension}".format(
                 root=force_text(self.file_object.filename_root),
                 options=self.options_as_string,
                 extension=self.file_object.extension,
             )
-        else:
+        except NameError:
             name = "{root}_{options}{extension}".format(
                 root=decode(self.file_object.filename_root),
                 options=self.options_as_string,

--- a/filebrowser/namers.py
+++ b/filebrowser/namers.py
@@ -2,7 +2,9 @@ from __future__ import unicode_literals
 import re
 from django.utils import six
 from django.utils.module_loading import import_string
-from django.utils.text import force_text
+import django
+if django.VERSION <= (2, 0):
+    from django.utils.text import force_text
 
 from .settings import VERSIONS, VERSION_NAMER
 
@@ -34,11 +36,18 @@ class VersionNamer(object):
 class OptionsNamer(VersionNamer):
 
     def get_version_name(self):
-        name = "{root}_{options}{extension}".format(
-            root=force_text(self.file_object.filename_root),
-            options=self.options_as_string,
-            extension=self.file_object.extension,
-        )
+        if django.VERSION <= (2, 0):
+            name = "{root}_{options}{extension}".format(
+                root=force_text(self.file_object.filename_root),
+                options=self.options_as_string,
+                extension=self.file_object.extension,
+            )
+        else:
+            name = "{root}_{options}{extension}".format(
+                root=decode(self.file_object.filename_root),
+                options=self.options_as_string,
+                extension=self.file_object.extension,
+            )
         return name
 
     def get_original_name(self):

--- a/filebrowser/namers.py
+++ b/filebrowser/namers.py
@@ -2,10 +2,8 @@ from __future__ import unicode_literals
 import re
 from django.utils import six
 from django.utils.module_loading import import_string
-try:
-    from django.utils.text import force_text
-except ImportError:
-    pass
+from django.utils.encoding import force_text
+
 
 from .settings import VERSIONS, VERSION_NAMER
 
@@ -37,18 +35,11 @@ class VersionNamer(object):
 class OptionsNamer(VersionNamer):
 
     def get_version_name(self):
-        try: # Django < 2.0
-            name = "{root}_{options}{extension}".format(
-                root=force_text(self.file_object.filename_root),
-                options=self.options_as_string,
-                extension=self.file_object.extension,
-            )
-        except NameError:
-            name = "{root}_{options}{extension}".format(
-                root=decode(self.file_object.filename_root),
-                options=self.options_as_string,
-                extension=self.file_object.extension,
-            )
+        name = "{root}_{options}{extension}".format(
+            root=force_text(self.file_object.filename_root),
+            options=self.options_as_string,
+            extension=self.file_object.extension,
+        )
         return name
 
     def get_original_name(self):

--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -8,10 +8,7 @@ from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.files.storage import DefaultStorage, default_storage, FileSystemStorage
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
-try:
-    from django.core.urlresolvers import reverse, get_urlconf, get_resolver
-except ImportError: # Django < 2.0
-    from django.urls import reverse, get_urlconf, get_resolver
+from django.urls import reverse, get_urlconf, get_resolver
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render, HttpResponse
 from django.template import RequestContext as Context

--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -3,13 +3,16 @@
 import os
 import re
 from time import gmtime, strftime, localtime, time
-
+import django
 from django import forms
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.files.storage import DefaultStorage, default_storage, FileSystemStorage
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
-from django.core.urlresolvers import reverse, get_urlconf, get_resolver
+if django.VERSION >= (2, 0):
+    from django.urls import reverse, get_urlconf, get_resolver
+else:
+    from django.core.urlresolvers import reverse, get_urlconf, get_resolver
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render, HttpResponse
 from django.template import RequestContext as Context

--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -3,16 +3,15 @@
 import os
 import re
 from time import gmtime, strftime, localtime, time
-import django
 from django import forms
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.files.storage import DefaultStorage, default_storage, FileSystemStorage
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
-if django.VERSION >= (2, 0):
-    from django.urls import reverse, get_urlconf, get_resolver
-else:
+try:
     from django.core.urlresolvers import reverse, get_urlconf, get_resolver
+except ImportError: # Django < 2.0
+    from django.urls import reverse, get_urlconf, get_resolver
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render, HttpResponse
 from django.template import RequestContext as Context

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -4,7 +4,10 @@ import os
 import json
 import shutil
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 2.0
+    from django.core.urlresolvers import reverse
 try:
     from django.utils.six.moves.urllib.parse import urlencode
 except:

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -4,10 +4,7 @@ import os
 import json
 import shutil
 
-try:
-    from django.urls import reverse
-except ImportError:  # Django < 2.0
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 try:
     from django.utils.six.moves.urllib.parse import urlencode
 except:


### PR DESCRIPTION
Tests: OK
Version: FileBrowser 3.9.1 Grappelli 2.10.1, Django 2.0

* Changed force_text to decode
* Changed imports for django.core.urlresolvers

```
The django.core.urlresolvers module is removed in favor of its new location, django.urls.

Removed support for bytestrings in some places
To support native Python 2 strings, older Django versions had to accept both bytestrings and unicode strings. Now that Python 2 support is dropped, bytestrings should only be encountered around input/output boundaries (handling of binary fields or HTTP streams, for example). You might have to update your code to limit bytestring usage to a minimum, as Django no longer accepts bytestrings in certain code paths.

For example, reverse() now uses str() instead of force_text() to coerce the args and kwargs it receives, prior to their placement in the URL. For bytestrings, this creates a string with an undesired b prefix as well as additional quotes (str(b'foo') is "b'foo'"). To adapt, call decode() on the bytestring before passing it to reverse().
```