### PR TITLE
Make sure FileBrowseFormField always returns a string

### DIFF
--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -72,8 +72,8 @@ class FileBrowseFormField(forms.CharField):
 
     def clean(self, value):
         value = super(FileBrowseFormField, self).clean(value)
-        if value == '':
-            return value
+        if not value:
+            return ''
         file_extension = os.path.splitext(value)[1].lower()
         if self.extensions and file_extension not in self.extensions:
             raise forms.ValidationError(self.error_messages['extension'] % {'ext': file_extension, 'allowed': ", ".join(self.extensions)})


### PR DESCRIPTION
Hi @sehmaschine ,

I'm not sure it it has to do with the fact that we are dealing with a translatable FileBrowseField but it used to work nicely with Django 1.8. 

With django-filebrowser 3.9.1 and more recent versions of Django (1.11.13) and/or Grappelli (2.9.1) I noticed l.74 could return `None`
Then arriving at l.77 we get a 500 error :(

> File "/Users/christineho/.virtualenvs/sff_local/lib/python2.7/site-packages/filebrowser/fields.py" in clean
>   77.         file_extension = os.path.splitext(value)[1].lower()
> 
> File "/Users/christineho/.virtualenvs/sff_local/lib/python2.7/posixpath.py" in splitext
>   98.     return genericpath._splitext(p, sep, altsep, extsep)
> 
> File "/Users/christineho/.virtualenvs/sff_local/lib/python2.7/genericpath.py" in _splitext
>   99.     sepIndex = p.rfind(sep)
> 
> Exception Type: AttributeError at /admin/content/image/455/change/
> Exception Value: 'NoneType' object has no attribute 'rfind'

This PR solves the problem and I'm hoping it's small enough to not have to be tested further but let me know :).