### PR TITLE
#358 Support string values for FileBrowseField default

### DIFF
--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -101,6 +101,8 @@ class FileBrowseField(CharField):
     def get_prep_value(self, value):
         if not value:
             return value
+        if type(value) is str:
+            return value
         return value.path
 
     def value_to_string(self, obj):


### PR DESCRIPTION
Hi,

I added a special case where the value of the `FileBrowseField` might be a string. This can occur if the `default` value for the field is set and given as a string.

This fixes #358.