### PR TITLE
Support for TinyMCE v4

### DIFF
--- a/filebrowser/static/filebrowser/js/FB_TinyMCEv4.js
+++ b/filebrowser/static/filebrowser/js/FB_TinyMCEv4.js
@@ -1,0 +1,16 @@
+/**
+ * Created by Sune Kjærgård on 04/02/2016.
+ * Originaly authored by Alan Hicks
+ * http://p-o.co.uk/tech-articles/howto-use-tinymce-with-django-filebrowser-media-manager/
+ */
+var FileBrowserDialogue = {
+    fileSubmit : function (FileURL) {
+        parentWin = (!window.frameElement && window.dialogArguments) || opener || parent || top;
+        tinymce = tinyMCE = parentWin.tinymce;
+        self.editor = tinymce.EditorManager.activeEditor;
+        self.params = self.editor.windowManager.getParams();
+        parentWin.document.getElementById(self.params.input).value = FileURL;
+        self.editor.windowManager.close(parentWin);
+    },
+}
+

--- a/filebrowser/templates/filebrowser/include/filelisting.html
+++ b/filebrowser/templates/filebrowser/include/filelisting.html
@@ -36,7 +36,7 @@
 
         <!-- FILESELECT FOR RTE/TINYMCE -->
         <!-- we need to use the absolute url here -->
-        {% if query.pop == "2" %}
+        {% if query.pop == "2" or query.pop == "4" %}
             <td class="fb_icon">
                 {% selectable fileobject.filetype query.type %}
                 {% if selectable %}

--- a/filebrowser/templates/filebrowser/include/tableheader.html
+++ b/filebrowser/templates/filebrowser/include/tableheader.html
@@ -7,6 +7,7 @@
         {% if query.pop == "1" %}<th></th>{% endif %}
         {% if query.pop == "2" %}<th></th>{% endif %}
         {% if query.pop == "3" %}<th></th>{% endif %}
+        {% if query.pop == "4" %}<th></th>{% endif %}
         <!-- FILETYPE -->
         {% if query.o == "filetype" %}<th class="grp-sorted grp-{{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% ifequal query.ot "desc" %}asc{% else %}desc{% endifequal %}&amp;o=filetype">{% trans "Type" %}</a></th>{% endif %}
         {% if query.o != "filetype" %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filetype">{% trans "Type" %}</a></th>{% endif %}

--- a/filebrowser/templates/filebrowser/index.html
+++ b/filebrowser/templates/filebrowser/index.html
@@ -23,6 +23,10 @@
     {% ifequal query.pop '3' %} <!-- CKeditor (former "FCKeditor") -->
     <script language="javascript" type="text/javascript" src="{% static "filebrowser/js/FB_CKEditor.js" %}"></script>
     {% endifequal %}
+    {% ifequal query.pop '4' %} <!-- TinyMCE v4 -->
+    <script language="javascript" type="text/javascript" src="{% static "filebrowser/js/FB_TinyMCEv4.js" %}"></script>
+    {% endifequal %}
+
     {{ media }}
     <script type="text/javascript" charset="utf-8">
         (function($) {

--- a/filebrowser/templates/filebrowser/version.html
+++ b/filebrowser/templates/filebrowser/version.html
@@ -46,7 +46,7 @@
             })(grp.jQuery);
         </script>
         {% endifequal %}
-        {% ifequal query.pop '2' %} <!-- TinyMCE -->
+        {% if query.pop == "2" or query.pop == "4" %} <!-- TinyMCE v2 and v4 -->
         <script type="text/javascript" charset="utf-8">
             (function($) {
                 $(document).ready(function() {
@@ -54,6 +54,6 @@
                 });
             })(grp.jQuery);
         </script>
-        {% endifequal %}
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/filebrowser/templates/filebrowser/version.html
+++ b/filebrowser/templates/filebrowser/version.html
@@ -20,6 +20,10 @@
     <script language="javascript" type="text/javascript" src="{% static "filebrowser/js/FB_TinyMCE.js" %}"></script>
     {% if query.mce_rdomain %}<script language="javascript">document.domain = "{{ query.mce_rdomain }}"</script>{% endif %}
     {% endifequal %}
+    {% ifequal query.pop '4' %} <!-- TinyMCEv4 -->
+    <script language="javascript" type="text/javascript" src="{% static "filebrowser/js/FB_TinyMCEv4.js" %}"></script>
+    {% endifequal %}
+
 {% endblock %}
 
 <!-- COLTYPE/BODYCLASS -->


### PR DESCRIPTION
It provides `TinyMCE v4` support into `django-filebrowser`

Thanks to @smacker and http://p-o.co.uk/tech-articles/howto-use-tinymce-with-django-filebrowser-media-manager

Until merge, it can be installable via https://github.com/XaviTorello/django-filebrowser-tinymcev4/archive/master.zip

Fix #368 Provide TinyMCE v4 support