### PR TITLE
Django 3.0 support

### DIFF
--- a/filebrowser/base.py
+++ b/filebrowser/base.py
@@ -7,9 +7,10 @@ import platform
 import tempfile
 import time
 
+from six import python_2_unicode_compatible, string_types
+
 from django.core.files import File
-from django.utils.encoding import python_2_unicode_compatible, force_text
-from django.utils.six import string_types
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 
 from filebrowser.settings import EXTENSIONS, SELECT_FORMATS, VERSIONS, ADMIN_VERSIONS, VERSIONS_BASEDIR, VERSION_QUALITY, STRICT_PIL, IMAGE_MAXBLOCK, DEFAULT_PERMISSIONS
@@ -225,7 +226,7 @@ class FileObject():
         self.mimetype = mimetypes.guess_type(self.filename)
 
     def __str__(self):
-        return force_text(self.path)
+        return force_str(self.path)
 
     @property
     def name(self):

--- a/filebrowser/management/commands/fb_version_generate.py
+++ b/filebrowser/management/commands/fb_version_generate.py
@@ -3,9 +3,10 @@
 import os
 import re
 
+from six.moves import input
+
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.six.moves import input
 
 from filebrowser.base import FileListing
 from filebrowser.settings import EXTENSION_LIST, EXCLUDE, DIRECTORY, VERSIONS

--- a/filebrowser/management/commands/fb_version_remove.py
+++ b/filebrowser/management/commands/fb_version_remove.py
@@ -3,9 +3,10 @@ import os
 import re
 import sys
 
+from six.moves import input
+
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.six.moves import input
 
 from filebrowser.settings import EXCLUDE, EXTENSIONS
 

--- a/filebrowser/namers.py
+++ b/filebrowser/namers.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import re
-from django.utils import six
+import six
+
 from django.utils.module_loading import import_string
 from django.utils.encoding import force_text
 

--- a/filebrowser/utils.py
+++ b/filebrowser/utils.py
@@ -5,7 +5,8 @@ import os
 import unicodedata
 import math
 
-from django.utils import six
+import six
+
 from django.utils.module_loading import import_string
 
 from filebrowser.settings import STRICT_PIL, NORMALIZE_FILENAME, CONVERT_FILENAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django-grappelli>=2.13,<2.14
 pillow
+six

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(
     install_requires=[
         'django-grappelli>=2.13,<2.14',
         'pillow',
+        'six',
     ],
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,5 +4,5 @@ funcsigs==0.4
 mock==1.3.0
 pbr==1.8.0
 Pillow>=3.3.2
-six==1.9.0
+six==1.13.0
 wheel==0.24.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-Django>=2.2,<2.3
+Django>=3.0,<3.1
 django-grappelli>=2.13,<2.14
 funcsigs==0.4
 mock==1.3.0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,9 +4,10 @@ import os
 import sys
 import shutil
 
+from six import StringIO
+
 from django.conf import settings
 from django.core.management import call_command
-from django.utils.six import StringIO
 
 from filebrowser.settings import DIRECTORY
 from tests import FilebrowserTestCase as TestCase


### PR DESCRIPTION
This changeset adds Django 3.0 support. Key changes are as follows:

* Change all references of `django.utils.six` to `six`. `django.utils.six` is no longer available in Django 3.0
* Change all references of `python_2_unicode_compatible` to the six's version of `python_2_unicode_compatible `
* Use `force_str ` instead of deprecated `force_text`
* Add `six` as a dependency 
* Update the test project to use Django 3.0
