### PR TITLE
Quickstart updated to work with Django 3.0

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,8 +11,9 @@ For using the |filebrowser|, `Django <http://www.djangoproject.com>`_ needs to b
 Requirements
 ------------
 
-* Django 1.11, http://www.djangoproject.com
-* Grappelli 2.9, https://github.com/sehmaschine/django-grappelli
+* Python 3.6+
+* Django 3.0, http://www.djangoproject.com
+* Grappelli 2.14, https://github.com/sehmaschine/django-grappelli
 * Pillow, https://github.com/python-imaging/Pillow
 
 Installation
@@ -28,23 +29,46 @@ Add the filebrowser to your ``INSTALLED_APPS`` (before django.contrib.admin):
 
 .. code-block:: python
 
-    INSTALLED_APPS = (
+    INSTALLED_APPS = [
         'grappelli',
         'filebrowser',
         'django.contrib.admin',
-    )
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.messages',
+        'django.contrib.staticfiles',
+    ]
 
 Add the |filebrowser| site to your url-patterns (before any admin-urls):
 
 .. code-block:: python
 
+    from django.contrib import admin
+    from django.urls import path
+    from django.urls import include
     from filebrowser.sites import site
+    from django.conf import settings
+    from django.conf.urls.static import static
 
     urlpatterns = [
-       path('admin/filebrowser/', site.urls),
-       path('grappelli/', include('grappelli.urls')),
-       path('admin/', admin.site.urls),
+        path('admin/filebrowser/', site.urls),
+        path('grappelli/', include('grappelli.urls')),
+        path('admin/', admin.site.urls),
     ]
+
+    # only for development server. File serving will be automatically disabled when DEBUG=False
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+Make sure you defined Django settings for media and static files (please refer to the `Settings Documentation <https://docs.djangoproject.com/en/dev/ref/settings/>`_ for more information):
+
+.. code-block:: python
+
+    # recommended values for media and static files
+    MEDIA_URL = '/media/'
+    MEDIA_ROOT = os.path.join(BASE_DIR, "media/")
+    STATIC_URL = '/static/'
+    STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 
 Collect the static files (please refer to the `Staticfiles Documentation <http://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/>`_ for more information):
 


### PR DESCRIPTION
Hi. Quickstart didn't work with both Django 2 and 3 as reported here: https://stackoverflow.com/questions/62025873/django-file-browser-can-upload-file-but-cant-open-file-with-404-error
This update fixes the problem in the docs.