### PR TITLE
Change ugettext_lazy to gettext_lazy due to deprecation

### DIFF
--- a/filebrowser/settings.py
+++ b/filebrowser/settings.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 # Main FileBrowser Directory. Relative to site.storage.location.


### PR DESCRIPTION
django.utils.deprecation.RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
It breaks nothing, works just fine