### PR TITLE
Add extra context

### DIFF
--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -270,6 +270,20 @@ class FileBrowserSite(object):
         "filebrowser.site URLs"
         return self.get_urls(), self.app_name, self.name
 
+     def _get_extra_context(self, request):
+        """
+        add extra context to filebrowser site
+        """
+
+        extra_context = {}
+
+        if hasattr(self,"add_extra_context"):
+            extra_context = self.add_extra_context(request)
+            if not isinstance(extra_context, dict):
+                raise TypeError('add_extra_context method must return a dict')
+
+        return extra_context
+      
     def browse(self, request):
         "Browse Files/Directories."
         filter_re = []
@@ -346,7 +360,8 @@ class FileBrowserSite(object):
             page = p.page(p.num_pages)
 
         request.current_app = self.name
-        return render(request, 'filebrowser/index.html', {
+        
+        context = {
             'p': p,
             'page': page,
             'filelisting': filelisting,
@@ -356,7 +371,11 @@ class FileBrowserSite(object):
             'breadcrumbs': get_breadcrumbs(query, query.get('dir', '')),
             'breadcrumbs_title': "",
             'filebrowser_site': self
-        })
+        }
+        
+        context.update(self._get_extra_context(request))
+        
+        return render(request, 'filebrowser/index.html', context)
 
     def createdir(self, request):
         "Create Directory"
@@ -385,7 +404,8 @@ class FileBrowserSite(object):
             form = CreateDirForm(path, filebrowser_site=self)
 
         request.current_app = self.name
-        return render(request, 'filebrowser/createdir.html', {
+        
+        context = {
             'form': form,
             'query': query,
             'title': _(u'New Folder'),
@@ -393,21 +413,30 @@ class FileBrowserSite(object):
             'breadcrumbs': get_breadcrumbs(query, query.get('dir', '')),
             'breadcrumbs_title': _(u'New Folder'),
             'filebrowser_site': self
-        })
+        }
+        
+        context.update(self._get_extra_context(request))
+        
+        return render(request, 'filebrowser/createdir.html', context)
 
     def upload(self, request):
         "Multipe File Upload."
         query = request.GET
 
         request.current_app = self.name
-        return render(request, 'filebrowser/upload.html', {
+        
+        context = {
             'query': query,
             'title': _(u'Select files to upload'),
             'settings_var': get_settings_var(directory=self.directory),
             'breadcrumbs': get_breadcrumbs(query, query.get('dir', '')),
             'breadcrumbs_title': _(u'Upload'),
             'filebrowser_site': self
-        })
+        }
+        
+        context.update(self._get_extra_context(request))
+        
+        return render(request, 'filebrowser/upload.html', context)
 
     def delete_confirm(self, request):
         "Delete existing File/Directory."
@@ -431,7 +460,8 @@ class FileBrowserSite(object):
             additional_files = None
 
         request.current_app = self.name
-        return render(request, 'filebrowser/delete_confirm.html', {
+        
+        context = {
             'fileobject': fileobject,
             'filelisting': filelisting,
             'additional_files': additional_files,
@@ -441,7 +471,11 @@ class FileBrowserSite(object):
             'breadcrumbs': get_breadcrumbs(query, query.get('dir', '')),
             'breadcrumbs_title': _(u'Confirm delete'),
             'filebrowser_site': self
-        })
+        }
+        
+        context.update(self._get_extra_context(request))
+        
+        return render(request, 'filebrowser/delete_confirm.html', context)
 
     def delete(self, request):
         "Delete existing File/Directory."
@@ -506,7 +540,8 @@ class FileBrowserSite(object):
             form = ChangeForm(initial={"name": fileobject.filename}, path=path, fileobject=fileobject, filebrowser_site=self)
 
         request.current_app = self.name
-        return render(request, 'filebrowser/detail.html', {
+        
+        context = {
             'form': form,
             'fileobject': fileobject,
             'query': query,
@@ -515,7 +550,11 @@ class FileBrowserSite(object):
             'breadcrumbs': get_breadcrumbs(query, query.get('dir', '')),
             'breadcrumbs_title': u'%s' % fileobject.filename,
             'filebrowser_site': self
-        })
+        }
+        
+        context.update(self._get_extra_context(request))
+        
+        return render(request, 'filebrowser/detail.html', context)
 
     def version(self, request):
         """
@@ -527,12 +566,17 @@ class FileBrowserSite(object):
         fileobject = FileObject(os.path.join(path, query.get('filename', '')), site=self)
 
         request.current_app = self.name
-        return render(request, 'filebrowser/version.html', {
+        
+        context = {
             'fileobject': fileobject,
             'query': query,
             'settings_var': get_settings_var(directory=self.directory),
             'filebrowser_site': self
-        })
+        }
+        
+        context.update(self._get_extra_context(request))
+        
+        return render(request, 'filebrowser/version.html', context)
 
     def _upload_file(self, request):
         """


### PR DESCRIPTION
Add the ability to push extra context:
example
```
def add_extra_context(self, request):
    
    query = request.GET.copy()

    if not query.get('pop'):
        from django.contrib.admin.sites import site
        return {
            'is_popup': query.get('pop'),
            'is_nav_sidebar_enabled': not query.get('pop'),
            'app_full_list': site.get_app_list(request),
        }
    else:
        return {}
  
FileBrowserSite.add_extra_context = add_extra_context

# My Custom FileBrowser site
custom_site = FileBrowserSite(name='custom_filebrowser', storage=DefaultStorage())

```