### PR TITLE
Exclude pycache and simplify MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,7 @@
 include AUTHORS
 include README.rst
 include LICENSE
-recursive-include docs *
-recursive-include filebrowser/static *
-recursive-include filebrowser/templates *
-recursive-include filebrowser/locale *
-recursive-include filebrowser/management *
+graft docs
+graft filebrowser
+global-exclude __pycache__
+global-exclude *.pyc


### PR DESCRIPTION
@sehmaschine check my changes please:
* simplified `recursive-include` with `graft` — [info from documentation](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html):
  > `graft dir-pattern`    |    Add all files under directories matching `dir-pattern`
* added `global-exclude` for `__pycache__` and `*.pyc` — because got warning when installed Django FileBrowser 5.0.1 with Poetry:
  > usr/local/lib/python3.12/site-packages/poetry/installation/wheel_installer.py:129: RuntimeWarning: Skip installing filebrowser/management/__pycache__/__init__.cpython-36.pyc from django_filebrowser. Installing files in a __pycache__ directory poses a security risk. __pycache__ directories should not be included in wheels. This is probably an issue in the build process of 'django_filebrowser'.